### PR TITLE
Simplifier la gestion de la bd

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,5 +19,8 @@
 		"astro",
 		"typescript",
 		"typescriptreact"
-	]
+	],
+	"[astro]": {
+		"editor.formatOnSave": false,
+	}
 }

--- a/src/lib/bd.mjs
+++ b/src/lib/bd.mjs
@@ -1,7 +1,10 @@
 // Importation du paquet NPM pour MongoDB:
-import mongoose from "mongoose";
-import ModeleSession from "./models/session.mjs";
-import ModeleUsager from "./models/usager.mjs";
+import mongoose, { Model, model } from "mongoose";
+
+// Importation des schémas:
+import SchemaSession from "./models/session.mjs";
+import SchemaUsager from "./models/usager.mjs";
+import SchemaAppreciation from "./models/appreciation.mjs";
 
 // Importation des interfaces:
 /** @typedef {import("./interfaces.mjs").IDateEvenement} IDateEvenement */
@@ -21,88 +24,28 @@ if (urlConnexion == null || urlConnexion.length < 1 || nomBase == null || nomBas
 	throw new Error("Veuillez configurer un fichier .env contenant une clé MONGO_URL.");
 }
 
+// Connexion à mongo avec la connexion Mongoose par défaut:
+await mongoose.connect(urlConnexion);
+await mongoose.connection.useDb(nomBase);
+
+// Création des modèles à partir des schémas:
+const Session = model("Session", SchemaSession);
+const Usager = model("Usager", SchemaSession);
+const Appreciation = model("Appreciation", SchemaAppreciation);
+
 
 /**
  * Classe de communication avec la base MongoDB
  */
 export default class Bd {
-	/***************************************************************************
-	 ************************* Propriétés statiques ****************************
-	 **************************************************************************/
-
-	/**
-	 * Référence de connexion à MongoDB
-	 * @type {mongoose.Connection}
-	 */
-	static #client = null;
-
-	/**
-	 * Référence aux collections de la base de données.
-	 * @type {Map<String,mongoose.Model>}
-	 */
-	static #collections = new Map();
-
-
-
-	/***************************************************************************
-	 *************************** Méthodes privées ******************************
-	 **************************************************************************/
-
-	/**
-	 * Établit une connexion avec la base de données si ce n'est pas déjà fait.
-	 */
-	static async #etablirConnexionAvecBase() {
-		// Si déjà connecté, nul besoin de reconnecter:
-		if (Bd.#client !== null) {
-			return;
-		}
-
-		// Connexion au serveur MongoDB:
-		Bd.#client = await mongoose.createConnection(urlConnexion);
-
-		// Connexion à la base de données:
-		Bd.#client.useDb(nomBase);
-	}
-
-	/**
-	 * Initialise les modèles et collections de la base MongoDB
-	 */
-	static async #initialiserModeles() {
-		await this.#etablirConnexionAvecBase();
-
-		Bd.#collections
-			.set("sessions", Bd.#client.model("Session", ModeleSession))
-			.set("usagers", Bd.#client.model("Usager", ModeleUsager));
-	}
-
-	/**
-	 * Obtient une référence à la collection donnée en paramètre.
-	 * @param {String} nom nom de la collection
-	 * @returns {Promise<mongoose.Model>} Une référence à la collection MongoDB
-	 */
-	static async #obtenirCollection(nom) {
-		if (Bd.#collections.size < 1) {
-			await Bd.#initialiserModeles();
-		}
-
-		return Bd.#collections.get(nom);
-	}
-
-
-
-	/***************************************************************************
-	 ************************** Méthodes publiques *****************************
-	 **************************************************************************/
-
 	/**
 	 * Obtient une session ayant la clé donnée.
 	 *
 	 * @param {String} cleSession clé publique de la session
-	 * @returns {typeof ModeleSession}
+	 * @returns {typeof SchemaSession}
 	 */
 	static async obtenirSession(cleSession) {
-		const sessions = await Bd.#obtenirCollection("sessions");
-		return await sessions.findOne({ cle: cleSession, dateExpiration: { $gt: new Date() } });
+		return await Session.findOne({ cle: cleSession, dateExpiration: { $gt: new Date() } });
 	}
 
 	/**
@@ -111,9 +54,8 @@ export default class Bd {
 	 * @param {String} idUsager identifiant unique de l'usager
 	 */
 	static async supprimerSession(idUsager) {
-		const sessions = await Bd.#obtenirCollection("sessions");
 		const usager = new ObjectId(idUsager);
-		await sessions.deleteOne({ usager: usager });
+		await Session.deleteOne({ usager: usager });
 	}
 
 	/**
@@ -122,13 +64,12 @@ export default class Bd {
 	 * @param {String} cleSession clé publique de la session
 	 * @param {String} idUsager identifiant unique de l'usager
 	 * @param {Date} expiration date d'expiration de la session
-	 * @returns {typeof ModeleSession}
+	 * @returns {typeof SchemaSession}
 	 */
 	static async nouvSession(cleSession, idUsager, expiration) {
-		const sessions = await Bd.#obtenirCollection("sessions");
 		await Bd.supprimerSession(idUsager);
 		const usager = new ObjectId(idUsager);
-		const session = new sessions({
+		const session = new Session({
 			cle: cleSession,
 			usager: usager,
 			dateExpiration: expiration
@@ -136,16 +77,5 @@ export default class Bd {
 		await session.save();
 
 		return session;
-	}
-
-	/**
-	 * Obtient tous les champs d'un document de la collection `danses`
-	 *
-	 * @param {String} permalien Le permalien de la danse
-	 * @returns Les détails de la danse
-	 */
-	static async obtenirDetailsDanse(permalien) {
-		const danses = await Bd.#obtenirCollection("danses");
-		return await danses.findOne({ permalien: permalien });
 	}
 }

--- a/src/lib/bd.mjs
+++ b/src/lib/bd.mjs
@@ -29,8 +29,11 @@ await mongoose.connect(urlConnexion);
 await mongoose.connection.useDb(nomBase);
 
 // Création des modèles à partir des schémas:
-const Session = model("Session", SchemaSession);
+/** @type {Model<SchemaSession>} */
+export const Session = model("Session", SchemaSession);
+/** @type {Model<SchemaUsager>} */
 const Usager = model("Usager", SchemaSession);
+/** @type {Model<SchemaAppreciation>} */
 const Appreciation = model("Appreciation", SchemaAppreciation);
 
 
@@ -42,7 +45,7 @@ export default class Bd {
 	 * Obtient une session ayant la clé donnée.
 	 *
 	 * @param {String} cleSession clé publique de la session
-	 * @returns {typeof SchemaSession}
+	 * @returns {Promise<Session>} instance de la Session
 	 */
 	static async obtenirSession(cleSession) {
 		return await Session.findOne({ cle: cleSession, dateExpiration: { $gt: new Date() } });
@@ -52,6 +55,7 @@ export default class Bd {
 	 * Supprime la session de l'usager donné.
 	 *
 	 * @param {String} idUsager identifiant unique de l'usager
+	 * @returns {Promise<void>} rien
 	 */
 	static async supprimerSession(idUsager) {
 		const usager = new ObjectId(idUsager);
@@ -64,7 +68,7 @@ export default class Bd {
 	 * @param {String} cleSession clé publique de la session
 	 * @param {String} idUsager identifiant unique de l'usager
 	 * @param {Date} expiration date d'expiration de la session
-	 * @returns {typeof SchemaSession}
+	 * @returns {Promise<Session>} instance de la nouvelle Session
 	 */
 	static async nouvSession(cleSession, idUsager, expiration) {
 		await Bd.supprimerSession(idUsager);

--- a/src/lib/session.mjs
+++ b/src/lib/session.mjs
@@ -3,7 +3,7 @@ import { AstroCookies } from "astro";
 import { chaineAleatoire } from "./cryptographie.mjs";
 import Bd from "./bd.mjs";
 // eslint-disable-next-line no-unused-vars
-import ModeleSession from "./models/session.mjs";
+import { Session as ModeleSession } from "./bd.mjs";
 
 /**
  * Nombre d'heures avant qu'une session expire et que l'utilisateur doivent se
@@ -34,7 +34,7 @@ export default class Session {
 	 *
 	 * @param {AstroCookies} cookies Référence à l'instance de Astro.cookies
 	 * @param {String} idUsager Identifiant de l'usager
-	 * @returns {typeof ModeleSession} une référence à la nouvelle session
+	 * @returns {Promise<ModeleSession>} une référence à la nouvelle session
 	 */
 	static async nouvSession(cookies, idUsager) {
 		// Création de la clé de session:
@@ -62,8 +62,8 @@ export default class Session {
 	 * Restaure une session à partir d'un cookie encrypté.
 	 *
 	 * @param {AstroCookies} cookies Référence à l'instance de Astro.cookies
-	 * @returns {typeof ModeleSession} Une nouvelle instance de la classe ou null si aucune
-	 * session existe pour l'usager
+	 * @returns {Promise<ModeleSession>} Une nouvelle instance de la classe ou
+	 * null si aucune session existe pour l'usager
 	 */
 	static async obtenirDepuisCookie(cookies) {
 		const cleSession = cookies.get(NOM_COOKIE)?.value;

--- a/src/lib/session.mjs
+++ b/src/lib/session.mjs
@@ -77,11 +77,17 @@ export default class Session {
 	}
 
 	/**
-	 * Détruire le cookie de session de l'utilisateur.
+	 * Détruire la session de l'utilisateur.
 	 *
 	 * @param {AstroCookies} cookies Référence à l'instance de Astro.cookies
 	 */
 	static async detruire(cookies) {
+		const session = await Session.obtenirDepuisCookie(cookies);
+
+		if (session != null) {
+			session.deleteOne();
+		}
+
 		cookies.delete(NOM_COOKIE);
 	}
 }

--- a/src/middleware/index.mjs
+++ b/src/middleware/index.mjs
@@ -2,10 +2,23 @@ import { sequence, defineMiddleware } from "astro/middleware";
 import Session from "../lib/session.mjs";
 
 
+/**
+ * Middleware qui récupère la session de l'usager depuis ses cookies et injecte
+ * le modèle Usager dans chaque route
+ */
 const middlewareSession = defineMiddleware(async (context, next) => {
+	// Récupération de la Session depuis les cookies:
 	const session = await Session.obtenirDepuisCookie(context.cookies);
-	context.locals.session = session;
-	context.locals.estConnecte = session && !session.estExpiree;
+
+	// Instance de l'usager connecté:
+	context.locals.usager = null; // null par défaut (non connecté)
+
+	// Si l'usager est connecté, on expose l'instance de Usager:
+	if (session && !session.estExpiree) {
+		await session.populate("usager");
+		context.locals.usager = session.usager._doc;
+	}
+
 	return next();
 });
 

--- a/src/pages/exemple-session/deconnexion.astro
+++ b/src/pages/exemple-session/deconnexion.astro
@@ -1,12 +1,6 @@
 ---
 import Session from "../../lib/session.mjs";
 
-const session = Astro.locals["session"];
-if (session) {
-	await session?.deleteOne();
-}
-
 Session.detruire(Astro.cookies);
-
 return Astro.redirect("/exemple-session");
 ---

--- a/src/pages/exemple-session/index.astro
+++ b/src/pages/exemple-session/index.astro
@@ -1,17 +1,26 @@
 ---
 import Page from "../../layouts/GabaritPrincipal.astro";
 
-const session = Astro.locals["session"];
-
-// OPTIONNEL: obtenir les détails de l'usagé associé à la session:
-await session?.populate("usager");
+const usager = Astro.locals["usager"];
 ---
 
 <Page titre="Session">
-	<p>
-		Contenu de la session:
-		<pre>{JSON.stringify(session)}</pre>
-	</p>
+	{
+		usager &&
+		<p>
+			Usager connecté:
+			<pre>
+				Prénom: {usager.prenom}
+				Nom: {usager.nom}
+			</pre>
+		</p>
+	}
+	{
+		!usager &&
+		<p>
+			(non connecté)
+		</p>
+	}
 
 	<a href="/exemple-session/nouv">[Nouvelle session]</a>
 	<a href="/exemple-session/deconnexion">[Déconnexion]</a>

--- a/src/pages/exemple-session/nouv.astro
+++ b/src/pages/exemple-session/nouv.astro
@@ -1,9 +1,9 @@
 ---
 import Session from "../../lib/session.mjs";
 
-Astro.locals["session"] = await Session.nouvSession(
+await Session.nouvSession(
 	Astro.cookies,
-	"64efcd939a22a43b7655725e"
+	"64f2128f1ecdc2e592625896"
 );
 
 return Astro.redirect("/exemple-session");


### PR DESCRIPTION
- On utilise une seule instance de mongoose donc nul besoin d'utiliser createConnection
  - nul besoin d'avoir un cache des collections
- L'objet Usager est injecté directement dans toutes les vues