### PR TITLE
faire fonctionner la page 404 en production

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,5 +1,7 @@
 ---
 import Page from "../layouts/GabaritPrincipal.astro";
+
+Astro.response.status = 404;
 ---
 
 <Page titre="Page introuvable">

--- a/src/pages/[...introuvable].astro
+++ b/src/pages/[...introuvable].astro
@@ -1,0 +1,5 @@
+---
+import Page404 from "./404.astro";
+---
+
+<Page404></Page404>


### PR DESCRIPTION
Le serveur de développement de Astro s'occupe lui-même de rediriger vers la route /404, mais en production, c'est le rôle du serveur de l'hébergeur de faire cette substitution de route. Puisque ce n'est pas possible ni avec Render et ni avec DigitalOcean, on utilise un *slug* recursif pour faire la même chose que le serveur de développement fait à l'interne.